### PR TITLE
feat: ABP-style wildcard support for custom blocklists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pihole-blocklist-optimizer"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 description = "Downloads, optimizes, and organizes Pi-hole blocklists"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ patterns.
 Define blocklist sources in `blocklists.conf`:
 
 ```
-url|name|category
+url|name|category[|flags]
 ```
 
 Example:
@@ -143,10 +143,17 @@ Example:
 ```
 https://adaway.org/hosts.txt|adaway|advertising
 https://someonewhocares.org/hosts/hosts|someonewhocares|comprehensive
+https://raw.githubusercontent.com/you/lists/main/custom.txt|custom|malicious|abp
 ```
 
 Categories: `advertising`, `tracking`, `malicious`, `suspicious`, `nsfw`,
 `comprehensive`
+
+Optional `flags` (4th field): `abp` enables ABP-style wildcard entries for that
+source. On an `abp` source, the lines `||domain^` and `*.domain` block the domain
+and all its subdomains (emitted as `||domain^` in the output); without the flag,
+those forms flatten to an exact domain. Use only on trusted, curated sources.
+ABP-style entries require Pi-hole Core ≥ 5.16 / FTL ≥ 5.22 (released 2023).
 
 Lines starting with `#` are ignored.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,6 @@ pub struct Blocklist {
     pub url: String,
     pub name: String,
     pub category: String,
-    #[allow(dead_code)]
     pub allow_wildcards: bool,
     pub etag: Option<String>,
     pub last_modified: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,8 +28,50 @@ pub struct Blocklist {
     pub url: String,
     pub name: String,
     pub category: String,
+    #[allow(dead_code)]
+    pub allow_wildcards: bool,
     pub etag: Option<String>,
     pub last_modified: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ParsedSource {
+    pub url: String,
+    pub name: String,
+    pub category: String,
+    pub allow_wildcards: bool,
+}
+
+pub fn parse_source_line(line: &str) -> Option<ParsedSource> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+        return None;
+    }
+
+    let parts: Vec<&str> = line.split('|').collect();
+    if parts.len() != 3 && parts.len() != 4 {
+        return None;
+    }
+
+    let url = parts[0].trim();
+    let name = parts[1].trim();
+    let category = parts[2].trim();
+
+    if Url::parse(url).is_err() {
+        return None;
+    }
+
+    let allow_wildcards = parts
+        .get(3)
+        .map(|f| f.trim().eq_ignore_ascii_case("abp"))
+        .unwrap_or(false);
+
+    Some(ParsedSource {
+        url: url.to_string(),
+        name: name.to_string(),
+        category: category.to_string(),
+        allow_wildcards,
+    })
 }
 
 pub fn load_blocklists(config_file: &str, progress: &ProgressTracker) -> Result<Vec<Blocklist>> {
@@ -44,34 +86,25 @@ pub fn load_blocklists(config_file: &str, progress: &ProgressTracker) -> Result<
     let mut blocklists = Vec::new();
 
     for (line_num, line) in content.lines().enumerate() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
 
-        let parts: Vec<&str> = line.split('|').collect();
-        if parts.len() != 3 {
-            warn!("Invalid format on line {}: {line}", line_num + 1);
+        let Some(parsed) = parse_source_line(trimmed) else {
+            warn!("Invalid blocklist line {}: {line}", line_num + 1);
             continue;
-        }
+        };
 
-        let url = parts[0].trim();
-        let name = parts[1].trim();
-        let category = parts[2].trim();
-
-        if Url::parse(url).is_err() {
-            warn!("Invalid URL on line {}: {url}", line_num + 1);
-            continue;
-        }
-
-        let cached = progress.get(name);
+        let cached = progress.get(&parsed.name);
         let etag = cached.and_then(|c| c.etag.clone());
         let last_modified = cached.and_then(|c| c.last_modified.clone());
 
         blocklists.push(Blocklist {
-            url: url.to_string(),
-            name: name.to_string(),
-            category: category.to_string(),
+            url: parsed.url,
+            name: parsed.name,
+            category: parsed.category,
+            allow_wildcards: parsed.allow_wildcards,
             etag,
             last_modified,
         });
@@ -89,4 +122,44 @@ pub fn load_blocklists(config_file: &str, progress: &ProgressTracker) -> Result<
     );
 
     Ok(blocklists)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_three_field_line_without_wildcards() {
+        let p = parse_source_line("https://example.com/a.txt|name|advertising").unwrap();
+        assert_eq!(p.name, "name");
+        assert_eq!(p.category, "advertising");
+        assert!(!p.allow_wildcards);
+    }
+
+    #[test]
+    fn parses_abp_flag_as_allow_wildcards() {
+        let p = parse_source_line("https://example.com/a.txt|name|advertising|abp").unwrap();
+        assert!(p.allow_wildcards);
+        let upper = parse_source_line("https://example.com/a.txt|name|advertising|ABP").unwrap();
+        assert!(upper.allow_wildcards);
+    }
+
+    #[test]
+    fn unknown_fourth_field_is_not_wildcards() {
+        let p = parse_source_line("https://example.com/a.txt|name|advertising|xyz").unwrap();
+        assert!(!p.allow_wildcards);
+    }
+
+    #[test]
+    fn skips_comment_and_blank_lines() {
+        assert!(parse_source_line("# comment").is_none());
+        assert!(parse_source_line("   ").is_none());
+    }
+
+    #[test]
+    fn rejects_bad_field_counts_and_urls() {
+        assert!(parse_source_line("a|b").is_none());
+        assert!(parse_source_line("a|b|c|d|e").is_none());
+        assert!(parse_source_line("not-a-url|n|advertising").is_none());
+    }
 }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -37,7 +37,40 @@ pub fn normalize_domain(domain: &str) -> String {
     domain.to_lowercase().trim_end_matches('.').to_string()
 }
 
-pub fn extract_domain_from_line(line: &str) -> Option<String> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Entry {
+    Exact(String),
+    Wildcard(String),
+}
+
+impl Entry {
+    pub fn to_key(&self) -> String {
+        match self {
+            Entry::Exact(d) => d.clone(),
+            Entry::Wildcard(d) => format!("||{d}^"),
+        }
+    }
+}
+
+fn make_exact(domain: &str) -> Option<Entry> {
+    let d = normalize_domain(domain);
+    if !d.contains('*') && validate_domain(&d) {
+        Some(Entry::Exact(d))
+    } else {
+        None
+    }
+}
+
+fn make_wildcard(domain: &str) -> Option<Entry> {
+    let d = normalize_domain(domain);
+    if !d.contains('*') && validate_domain(&d) {
+        Some(Entry::Wildcard(d))
+    } else {
+        None
+    }
+}
+
+pub fn extract_entry(line: &str, allow_wildcards: bool) -> Option<Entry> {
     let line = line.trim();
     if line.is_empty() || line.starts_with('#') || line.starts_with('!') {
         return None;
@@ -49,19 +82,29 @@ pub fn extract_domain_from_line(line: &str) -> Option<String> {
         return None;
     }
 
-    // IP-domain format: 0.0.0.0 domain.com or 127.0.0.1 domain.com
     if let Some(caps) = IP_DOMAIN_RE.captures(line) {
-        return caps.get(1).map(|m| m.as_str().to_string());
+        return make_exact(caps.get(1)?.as_str());
     }
 
-    // AdBlock format: ||domain.com^ or ||domain.com^$third-party
     if let Some(caps) = ADBLOCK_RE.captures(line) {
-        return caps.get(1).map(|m| m.as_str().to_string());
+        let domain = caps.get(1)?.as_str();
+        return if allow_wildcards {
+            make_wildcard(domain)
+        } else {
+            make_exact(domain)
+        };
     }
 
-    // Plain domain: no spaces, slashes, or question marks
+    if let Some(stripped) = line.strip_prefix("*.") {
+        return if allow_wildcards {
+            make_wildcard(stripped)
+        } else {
+            make_exact(stripped)
+        };
+    }
+
     if !line.contains(' ') && !line.contains('/') && !line.contains('?') {
-        return Some(line.to_string());
+        return make_exact(line);
     }
 
     None
@@ -101,44 +144,67 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_ip_domain() {
+    fn test_extract_entry_hosts_and_plain() {
         assert_eq!(
-            extract_domain_from_line("0.0.0.0 ads.example.com"),
-            Some("ads.example.com".to_string())
+            extract_entry("0.0.0.0 ads.example.com", true),
+            Some(Entry::Exact("ads.example.com".to_string()))
         );
         assert_eq!(
-            extract_domain_from_line("127.0.0.1 tracker.com"),
-            Some("tracker.com".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_adblock() {
-        assert_eq!(
-            extract_domain_from_line("||ads.example.com^"),
-            Some("ads.example.com".to_string())
-        );
-        assert_eq!(
-            extract_domain_from_line("||tracker.com^$third-party"),
-            Some("tracker.com".to_string())
+            extract_entry("ads.example.com", false),
+            Some(Entry::Exact("ads.example.com".to_string()))
         );
     }
 
     #[test]
-    fn test_extract_plain_domain() {
+    fn test_extract_entry_abp_respects_flag() {
         assert_eq!(
-            extract_domain_from_line("ads.example.com"),
-            Some("ads.example.com".to_string())
+            extract_entry("||foo.com^", true),
+            Some(Entry::Wildcard("foo.com".to_string()))
+        );
+        assert_eq!(
+            extract_entry("||foo.com^", false),
+            Some(Entry::Exact("foo.com".to_string()))
+        );
+        assert_eq!(
+            extract_entry("||tracker.com^$third-party", true),
+            Some(Entry::Wildcard("tracker.com".to_string()))
         );
     }
 
     #[test]
-    fn test_extract_comments() {
-        assert_eq!(extract_domain_from_line("# comment"), None);
-        assert_eq!(extract_domain_from_line("! comment"), None);
+    fn test_extract_entry_star_sugar_respects_flag() {
         assert_eq!(
-            extract_domain_from_line("ads.example.com # inline comment"),
-            Some("ads.example.com".to_string())
+            extract_entry("*.bar.com", true),
+            Some(Entry::Wildcard("bar.com".to_string()))
+        );
+        assert_eq!(
+            extract_entry("*.bar.com", false),
+            Some(Entry::Exact("bar.com".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_extract_entry_rejects_junk() {
+        assert_eq!(extract_entry("# comment", true), None);
+        assert_eq!(extract_entry("", true), None);
+        assert_eq!(extract_entry("||*.^", true), None);
+        assert_eq!(extract_entry("*.", true), None);
+    }
+
+    #[test]
+    fn test_extract_entry_inline_comment() {
+        assert_eq!(
+            extract_entry("ads.example.com # inline comment", true),
+            Some(Entry::Exact("ads.example.com".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_entry_to_key() {
+        assert_eq!(Entry::Exact("foo.com".to_string()).to_key(), "foo.com");
+        assert_eq!(
+            Entry::Wildcard("foo.com".to_string()).to_key(),
+            "||foo.com^"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,9 @@ use std::process;
 
 #[derive(Parser)]
 #[command(name = "pihole-optimizer")]
-#[command(version = "3.0.0")]
+#[command(version)]
 #[command(
-    about = "Pi-hole Blocklist Optimizer v3.0 — Downloads, optimizes, and organizes Pi-hole blocklists"
+    about = "Pi-hole Blocklist Optimizer v3.1 — Downloads, optimizes, and organizes Pi-hole blocklists"
 )]
 struct Cli {
     /// Configuration file path

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 
 use crate::client::HttpClient;
 use crate::config::{load_blocklists, AppConfig};
-use crate::domain::{extract_domain_from_line, format_num, normalize_domain, validate_domain};
+use crate::domain::{extract_entry, format_num};
 use crate::progress::ProgressTracker;
 use crate::whitelist::WhitelistManager;
 
@@ -63,7 +63,7 @@ impl BlocklistManager {
                     .join(&bl.category)
                     .join(format!("{}.txt", bl.name));
                 if path.exists() {
-                    match load_domains_from_file(&path) {
+                    match load_domains_from_file(&path, bl.allow_wildcards) {
                         Ok(domains) => {
                             debug!("  {}: {} domains (from file)", bl.name, domains.len());
                             category_domains
@@ -149,7 +149,7 @@ impl BlocklistManager {
                             .join(&bl.category)
                             .join(format!("{}.txt", bl.name));
                         if path.exists() {
-                            if let Ok(domains) = load_domains_from_file(&path) {
+                            if let Ok(domains) = load_domains_from_file(&path, bl.allow_wildcards) {
                                 category_domains
                                     .entry(bl.category.clone())
                                     .or_default()
@@ -159,7 +159,7 @@ impl BlocklistManager {
                     }
                     Ok(dl) => {
                         let content = dl.content.expect("modified response must have content");
-                        let domains = process_content(&content);
+                        let domains = process_content(&content, bl.allow_wildcards);
                         let count = domains.len();
 
                         if count == 0 {
@@ -312,23 +312,21 @@ impl BlocklistManager {
     }
 }
 
-fn process_content(content: &[u8]) -> HashSet<String> {
+fn process_content(content: &[u8], allow_wildcards: bool) -> HashSet<String> {
     let text = String::from_utf8_lossy(content);
     let mut domains = HashSet::new();
     for line in text.lines() {
-        if let Some(domain) = extract_domain_from_line(line) {
-            if validate_domain(&domain) {
-                domains.insert(normalize_domain(&domain));
-            }
+        if let Some(entry) = extract_entry(line, allow_wildcards) {
+            domains.insert(entry.to_key());
         }
     }
     domains
 }
 
-fn load_domains_from_file(path: &Path) -> Result<HashSet<String>> {
+fn load_domains_from_file(path: &Path, allow_wildcards: bool) -> Result<HashSet<String>> {
     let content =
         std::fs::read(path).with_context(|| format!("Failed to read {}", path.display()))?;
-    Ok(process_content(&content))
+    Ok(process_content(&content, allow_wildcards))
 }
 
 fn write_blocklist_file(path: &Path, domains: &HashSet<String>, label: Option<&str>) -> Result<()> {
@@ -348,10 +346,18 @@ fn write_blocklist_file(path: &Path, domains: &HashSet<String>, label: Option<&s
     writeln!(w)?;
 
     for domain in sorted {
-        writeln!(w, "0.0.0.0 {domain}")?;
+        writeln!(w, "{}", format_blocklist_line(domain))?;
     }
 
     Ok(())
+}
+
+fn format_blocklist_line(key: &str) -> String {
+    if key.starts_with("||") {
+        key.to_string()
+    } else {
+        format!("0.0.0.0 {key}")
+    }
 }
 
 fn capitalize(s: &str) -> String {
@@ -359,5 +365,32 @@ fn capitalize(s: &str) -> String {
     match chars.next() {
         None => String::new(),
         Some(first) => first.to_uppercase().to_string() + chars.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_content_emits_wildcards_when_enabled() {
+        let set = process_content(b"||foo.com^\n*.bar.com\n0.0.0.0 baz.com\n", true);
+        assert!(set.contains("||foo.com^"));
+        assert!(set.contains("||bar.com^"));
+        assert!(set.contains("baz.com"));
+    }
+
+    #[test]
+    fn process_content_flattens_when_disabled() {
+        let set = process_content(b"||foo.com^\n*.bar.com\n", false);
+        assert!(set.contains("foo.com"));
+        assert!(set.contains("bar.com"));
+        assert!(!set.iter().any(|d| d.contains('*') || d.starts_with("||")));
+    }
+
+    #[test]
+    fn format_blocklist_line_handles_both_forms() {
+        assert_eq!(format_blocklist_line("foo.com"), "0.0.0.0 foo.com");
+        assert_eq!(format_blocklist_line("||foo.com^"), "||foo.com^");
     }
 }


### PR DESCRIPTION
## What

Adds opt-in ABP-style (`||domain^`) wildcard support so curated sources can block a domain **and all its subdomains** in one line. Bumps to **v3.1.0**.

- **`config.rs`** — `blocklists.conf` gains an optional 4th field; `abp` sets a per-source `allow_wildcards` flag. Existing 3-field lines are unchanged.
- **`domain.rs`** — `extract_domain_from_line` → typed `extract_entry(line, allow_wildcards) -> Option<Entry>` where `Entry` is `Exact` or `Wildcard`. On an `abp` source, `||d^` and `*.d` become `Wildcard(d)`; otherwise both flatten to `Exact(d)`.
- **`pipeline.rs`** — threads the flag through parsing and writes `Wildcard` keys verbatim as `||d^` (no `0.0.0.0` prefix). Output lists become valid mixed hosts/ABP, which Pi-hole parses line-by-line.
- **`main.rs`** — `#[command(version)]` so `--version` reads `CARGO_PKG_VERSION` (Cargo.toml is now the single source of truth).

## Why

Pi-hole gravity can't express wildcards, but it natively matches ABP `||domain^` entries (Core ≥ 5.16 / FTL ≥ 5.22) against a domain and all subdomains. The optimizer already parsed `||domain^` but flattened it; this preserves the intent for trusted sources — letting a single custom entry (e.g. `||appsflyersdk.com^`) cover thousands of hashed subdomains.

## Scope / safety

- Wildcards are **opt-in per source**; the 59 upstream feeds are unaffected (still flatten `||`/`*.` to a bare exact domain).
- Incidentally fixes a latent bug: `*.x` lines previously produced a dead `0.0.0.0 *.x` entry; they now flatten to a real `0.0.0.0 x` block.
- Whitelist can't carve a subdomain out of a wildcard at build time (documented limitation; Pi-hole's runtime allow-precedence covers it).

## Verification

- `cargo test` (17 pass), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean; `--version` → `3.1.0`.
- End-to-end (`--skip-download`): an `abp` source with `||evil.example^`, `*.tracker.example`, `0.0.0.0 plain.example` emits `||evil.example^`, `||tracker.example^`, `0.0.0.0 plain.example`; the same source without the flag flattens all three to `0.0.0.0`, with no stray asterisks.

## Deployment ordering

The companion `Pi-hole-Optimized-Blocklists` change (adding `|abp` to the five `custom_*` sources) must **not** deploy until this release is published — the old v3.0.0 binary skips 4-field conf lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)