### PR TITLE
feat: --abp-lists subdomain-blocking output variants (v3.2.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pihole-blocklist-optimizer"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 description = "Downloads, optimizes, and organizes Pi-hole blocklists"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -199,11 +199,20 @@ Options:
       --dry-run                Show what would happen without doing it
       --no-whitelist-subdomain Disable subdomain matching in whitelist
       --whitelist-report       Generate detailed whitelist match report
+      --abp-lists <CATEGORIES> Also emit ABP-style variants (e.g. nsfw) that block subdomains
   -v, --verbose                Debug logging
   -q, --quiet                  Errors only
   -h, --help                   Print help
   -V, --version                Print version
 ```
+
+`--abp-lists` takes a comma-separated list of categories (e.g. `--abp-lists nsfw`). For
+each, the optimizer writes an additional `<category>_abp.txt` in the production directory
+where every entry is in ABP form (`||domain^`) so it blocks the domain **and all its
+subdomains**. The normal `<category>.txt` (exact-host) is still written unchanged. ABP
+entries require Pi-hole Core ≥ 5.16 / FTL ≥ 5.22, and are more aggressive — use for
+categories of dedicated domains (like NSFW) rather than lists that contain shared,
+multi-tenant hosts.
 
 ## Output Structure
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub struct AppConfig {
     pub verbose: bool,
     pub whitelist_subdomain: bool,
     pub whitelist_report: bool,
+    pub abp_lists: Vec<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::process;
 #[command(name = "pihole-optimizer")]
 #[command(version)]
 #[command(
-    about = "Pi-hole Blocklist Optimizer v3.1 — Downloads, optimizes, and organizes Pi-hole blocklists"
+    about = "Pi-hole Blocklist Optimizer — Downloads, optimizes, and organizes Pi-hole blocklists"
 )]
 struct Cli {
     /// Configuration file path
@@ -63,6 +63,10 @@ struct Cli {
     /// Generate detailed whitelist match report
     #[arg(long)]
     whitelist_report: bool,
+
+    /// Categories to also emit as an ABP-style variant (e.g. nsfw) that blocks subdomains
+    #[arg(long, value_delimiter = ',')]
+    abp_lists: Vec<String>,
 
     /// Verbose logging (debug level)
     #[arg(short, long)]
@@ -114,12 +118,16 @@ async fn main() {
         verbose: cli.verbose,
         whitelist_subdomain: !cli.no_whitelist_subdomain,
         whitelist_report: cli.whitelist_report,
+        abp_lists: cli.abp_lists,
     };
 
     if !config.quiet {
         println!();
         println!("{}", "=".repeat(60));
-        println!("{:>35}", "PI-HOLE BLOCKLIST OPTIMIZER v3.0");
+        println!(
+            "{:>35}",
+            format!("PI-HOLE BLOCKLIST OPTIMIZER v{}", env!("CARGO_PKG_VERSION"))
+        );
         println!("{}", "=".repeat(60));
         println!();
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -175,7 +175,7 @@ impl BlocklistManager {
 
                         // Save optimized file
                         let opt_path = cat_dir.join(format!("{}.txt", bl.name));
-                        if let Err(e) = write_blocklist_file(&opt_path, &domains, None) {
+                        if let Err(e) = write_blocklist_file(&opt_path, &domains, None, false) {
                             warn!("Failed to write optimized file for {}: {e}", bl.name);
                         }
 
@@ -276,7 +276,7 @@ impl BlocklistManager {
 
         // Write master file
         let master_path = Path::new(&self.config.prod_dir).join("all_domains.txt");
-        write_blocklist_file(&master_path, &filtered, Some("Master"))?;
+        write_blocklist_file(&master_path, &filtered, Some("Master"), false)?;
         info!(
             "Created Master blocklist: {} domains",
             format_num(filtered.len())
@@ -288,11 +288,26 @@ impl BlocklistManager {
                 let (cat_filtered, _) = self.whitelist.filter_domains(domains);
                 let cat_path = Path::new(&self.config.prod_dir).join(format!("{cat}.txt"));
                 let label = capitalize(cat);
-                write_blocklist_file(&cat_path, &cat_filtered, Some(&label))?;
+                write_blocklist_file(&cat_path, &cat_filtered, Some(&label), false)?;
                 info!(
                     "Created {label} blocklist: {} domains",
                     format_num(cat_filtered.len())
                 );
+
+                if self
+                    .config
+                    .abp_lists
+                    .iter()
+                    .any(|c| c.eq_ignore_ascii_case(cat))
+                {
+                    let abp_path = Path::new(&self.config.prod_dir).join(format!("{cat}_abp.txt"));
+                    let abp_label = format!("{label} (ABP)");
+                    write_blocklist_file(&abp_path, &cat_filtered, Some(&abp_label), true)?;
+                    info!(
+                        "Created {abp_label} blocklist: {} entries",
+                        format_num(cat_filtered.len())
+                    );
+                }
             }
         }
 
@@ -329,7 +344,12 @@ fn load_domains_from_file(path: &Path, allow_wildcards: bool) -> Result<HashSet<
     Ok(process_content(&content, allow_wildcards))
 }
 
-fn write_blocklist_file(path: &Path, domains: &HashSet<String>, label: Option<&str>) -> Result<()> {
+fn write_blocklist_file(
+    path: &Path,
+    domains: &HashSet<String>,
+    label: Option<&str>,
+    force_abp: bool,
+) -> Result<()> {
     let mut sorted: Vec<&String> = domains.iter().collect();
     sorted.sort();
 
@@ -346,7 +366,12 @@ fn write_blocklist_file(path: &Path, domains: &HashSet<String>, label: Option<&s
     writeln!(w)?;
 
     for domain in sorted {
-        writeln!(w, "{}", format_blocklist_line(domain))?;
+        let line = if force_abp {
+            format_abp_line(domain)
+        } else {
+            format_blocklist_line(domain)
+        };
+        writeln!(w, "{line}")?;
     }
 
     Ok(())
@@ -357,6 +382,14 @@ fn format_blocklist_line(key: &str) -> String {
         key.to_string()
     } else {
         format!("0.0.0.0 {key}")
+    }
+}
+
+fn format_abp_line(key: &str) -> String {
+    if key.starts_with("||") {
+        key.to_string()
+    } else {
+        format!("||{key}^")
     }
 }
 
@@ -392,5 +425,12 @@ mod tests {
     fn format_blocklist_line_handles_both_forms() {
         assert_eq!(format_blocklist_line("foo.com"), "0.0.0.0 foo.com");
         assert_eq!(format_blocklist_line("||foo.com^"), "||foo.com^");
+    }
+
+    #[test]
+    fn format_abp_line_wraps_exact_and_keeps_wildcards() {
+        assert_eq!(format_abp_line("foo.com"), "||foo.com^");
+        assert_eq!(format_abp_line("sub.foo.com"), "||sub.foo.com^");
+        assert_eq!(format_abp_line("||foo.com^"), "||foo.com^");
     }
 }


### PR DESCRIPTION
## What

New `--abp-lists <categories>` flag (comma-separated). For each named category the optimizer additionally writes `<category>_abp.txt` in the prod dir, with every entry in ABP form (`||domain^`) so it blocks the domain **and all its subdomains**. The normal exact-host `<category>.txt` is written unchanged.

Also: replaces the hardcoded version banner / `about` strings with `CARGO_PKG_VERSION` (they were stale at "v3.0"/"v3.1").

## Why

Requested in Pi-hole-Optimized-Blocklists#44 — the exact-host lists don't block subdomains, so e.g. `sub.adultsite.com` leaks past `nsfw.txt`. ABP variants close that gap. Kept as an **opt-in additional file** rather than converting lists in place: the exact-host format stays compatible with non-Pi-hole/hosts-file consumers, and the more-aggressive ABP form is reserved for categories of dedicated domains (NSFW), not lists with shared multi-tenant hosts.

## Verification

- `cargo test` (18 pass incl. new `format_abp_line`), `clippy -D warnings`, `fmt` clean; `--version` → 3.2.0.
- E2E (`--skip-download --abp-lists nsfw`): produces `nsfw.txt` (exact, unchanged) **and** `nsfw_abp.txt` (`||adult.example^`, `||porn.example^`, …); no variant emitted without the flag.

## Deployment note

The companion `update-blocklists.yml` change (passing `--abp-lists nsfw`) must not deploy until **v3.2.0** is the published release — the older binary would reject the unknown flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)